### PR TITLE
Modify 'app' to 'name'

### DIFF
--- a/selenium-hub-rc.yaml
+++ b/selenium-hub-rc.yaml
@@ -3,15 +3,15 @@ kind: ReplicationController
 metadata:
   name: selenium-hub
   labels:
-    app: selenium-hub
+    name: selenium-hub
 spec:
   replicas: 1
   selector:
-    app: selenium-hub
+    name: selenium-hub
   template:
     metadata:
       labels:
-        app: selenium-hub
+        name: selenium-hub
     spec:
       containers:
       - name: selenium-hub


### PR DESCRIPTION
I use the current yaml file to find this problem.
The key of the selector of hub service is 'name', and the hub rc`s
key is 'app', which does not correspond.